### PR TITLE
Create counts for Trading Status

### DIFF
--- a/docs/impala-business-index-scripts.md
+++ b/docs/impala-business-index-scripts.md
@@ -40,7 +40,7 @@ Bash script used in an environment which has access to the `impala-shell` comman
 
 ## Output
 
-Produces counts based on the `business_datasources` view, split by `Trading Status`. The output shows how many of records from each datasource were used to make the Business Index record. A summary row is included:
+Produces counts based on the `business_datasources` view, split by `Trading Status`. The output shows how many Business Index records were made up of only the sources described. A summary row is included:
 ```
 === Trading Status: ACTIVE ===
 Total Business Index: 3

--- a/docs/impala-business-index-scripts.md
+++ b/docs/impala-business-index-scripts.md
@@ -40,8 +40,9 @@ Bash script used in an environment which has access to the `impala-shell` comman
 
 ## Output
 
-Produces counts based on the `business_datasources` view, showing the counts on how many data sources are used to make a business index record. Output is printed to the console:
+Produces counts based on the `business_datasources` view, split by `Trading Status`. The output shows how many of records from each datasource were used to make the Business Index record. A summary row is included:
 ```
+=== Trading Status: ACTIVE ===
 Total Business Index: 3
 Companies House only: 0
 Companies House and VAT only: 0
@@ -50,4 +51,9 @@ Companies House and VAT and Paye: 0
 VAT only: 1
 VAT and Paye only: 0
 Paye only: 0
+
+=== Trading Status: SUMMARY ===
+...
+...
+
 ```

--- a/scripts/impala/GetBusinessIndexCounts.sh
+++ b/scripts/impala/GetBusinessIndexCounts.sh
@@ -22,10 +22,6 @@ then
     exit 1
 fi
 
-CH="CompaniesHouse"
-VAT="Vat"
-PAYE="Paye"
-
 DBNAME=""
 IMPALADAEMON=""
 
@@ -45,60 +41,114 @@ while getopts ":d:i:" opt; do
 done
 shift $((OPTIND-1))
 
-getCount='impala-shell -B --quiet -i '$IMPALADAEMON' -q'
+queryOptions[0]="-c"
+queryOptions[1]="-c -v"
+queryOptions[2]="-c -v -p"
+queryOptions[3]="-c -p"
+queryOptions[4]="-v"
+queryOptions[5]="-v -p"
+queryOptions[6]="-p"
 
-totalCountQuery="SELECT count(*) FROM $DBNAME.business_datasources ids"
+tradingStatus[0]="ACTIVE"
+tradingStatus[1]="CLOSED"
+tradingStatus[2]="INSOLVENT"
 
-chQuery="SELECT count(*) FROM $DBNAME.business_datasources ids
-WHERE ids.sources LIKE '%$CH%' 
-AND ids.sources NOT LIKE '%$VAT%' 
-AND ids.sources NOT LIKE '%$PAYE%'"
+function buildCountConditions {
+    local companiesHouseCondition="NOT LIKE '%CompaniesHouse%'"
+    local vatCondition="NOT LIKE '%Vat%'"
+    local payeCondition="NOT LIKE '%Paye%'"
 
-chVatQuery="SELECT count(*) FROM $DBNAME.business_datasources ids
-WHERE ids.sources LIKE '%$CH%' 
-AND ids.sources LIKE '%$VAT%' 
-AND ids.sources NOT LIKE '%$PAYE%'"
+    description=""
 
-chPayeQuery="SELECT count(*) FROM $DBNAME.business_datasources ids
-WHERE ids.sources LIKE '%$CH%' 
-AND ids.sources LIKE '%$PAYE%' 
-AND ids.sources NOT LIKE '%$VAT%'"
+    local OPTIND
+    while getopts "cvp" opt; do
+        case "$opt" in
+        c)
+          companiesHouseCondition="LIKE '%CompaniesHouse%'"
+          description="$description Companies House"
+          ;;
+        v)
+          vatCondition="LIKE '%Vat%'"
+          description="$description VAT"
+          ;;
+        p)
+          payeCondition="LIKE '%Paye%'"
+          description="$description Paye"
+          ;;
+        \?)
+        echo "Invalid option: -$OPTARG" >&2
+        exit 1
+        ;;
+        esac
+    done
+    shift $((OPTIND-1))
 
-chVatPayeQuery="SELECT count(*) FROM $DBNAME.business_datasources ids
-WHERE ids.sources LIKE '%$CH%' 
-AND ids.sources LIKE '%$PAYE%' 
-AND ids.sources LIKE '%$VAT%'"
+    return ("$description: " "business_datasources.sources $companiesHouseCondition
+      AND business_datasources.sources $vatCondition
+      AND business_datasources.sources $payeCondition")
+}
 
-vatQuery="SELECT count(*) FROM $DBNAME.business_datasources ids
-WHERE ids.sources LIKE '%$VAT%' 
-AND ids.sources NOT LIKE '%$PAYE%' 
-AND ids.sources NOT LIKE '%$CH%'"
+function executeCountQuery {
+  local fromClause=$0
+  local whereClause=$1
+  return $(impala-shell -B --quiet -i '$IMPALADAEMON' -q "SELECT count(*) FROM $fromClause WHERE $whereClause")
+}
 
-vatPayeQuery="SELECT count(*) FROM $DBNAME.business_datasources ids
-WHERE ids.sources LIKE '%$VAT%' 
-AND ids.sources LIKE '%$PAYE%' 
-AND ids.sources NOT LIKE '%$CH%'"
+function getCountsForTradingStatus {
+  countTradingStatusOutput=""
+  local fromClause="datasources_for_ids
+    LEFT JOIN
+    ( SELECT id, sr.tradingstatus from businessindex, businessindex.sourcerecords sr WHERE sr.datasource = 'CompaniesHouse'
+     ) AS ch 
+    ON ch.id = ids.id
+    LEFT JOIN
+    ( SELECT id, sr.tradingstatus from businessindex, businessindex.sourcerecords sr WHERE sr.datasource = 'Vat'
+     ) AS vat
+    ON vat.id = ids.id
+    LEFT JOIN
+    ( SELECT id, sr.tradingstatus from businessindex, businessindex.sourcerecords sr WHERE sr.datasource = 'Paye' 
+     ) AS paye
+    ON paye.id = ids.id"
 
-payeQuery="SELECT count(*) FROM $DBNAME.business_datasources ids
-WHERE ids.sources LIKE '%$PAYE%' 
-AND ids.sources NOT LIKE '%$VAT%' 
-AND ids.sources NOT LIKE '%$CH%'"
+  for status in "${tradingStatus[@]}"
+  do
+    countTradingStatusOutput="$countTradingStatusOutput \n === Trading Status: $status === \n"
 
-totalCount=$($getCount "$totalCountQuery" -r)
-ch=$($getCount "$chQuery")
-chVat=$($getCount "$chVatQuery")
-chPaye=$($getCount "$chPayeQuery")
-chVatPaye=$($getCount "$chVatPayeQuery")
-vat=$($getCount "$vatQuery")
-vatPaye=$($getCount "$vatPayeQuery")
-paye=$($getCount "$payeQuery")
+    for option in "${queryOptions[@]}"
+    do
+      whereClauseAndDescription=$(buildCountConditions $option)
+      tradingStatusWhereClause="$whereClauseAndDescription[1] 
+        AND and coalesce(ch.tradingstatus, vat.tradingstatus, paye.tradingstatus) = '$status'"
+      countTradingStatusOutput="$countTradingStatusOutput $whereClauseAndDescription[0]:"
+      countTradingStatusOutput="$countTradingStatusOutput $(executeCountQuery $fromClause $tradingStatusWhereClause) \n"
+    done
+  done
 
-echo "Total Business Index: ${totalCount//[$'\n']/}"
-echo "Companies House only: $ch"
-echo "Companies House and VAT only: $chVat"
-echo "Companies House and Paye only: $chPaye"
-echo "Companies House and VAT and Paye: $chVatPaye"
-echo "VAT only: $vat"
-echo "VAT and Paye only: $vatPaye"
-echo "Paye only: $paye"
+  return $countTradingStatusOutput
+}
 
+function getCountsForSourceTypes {
+  countOutput="=== SUMMARY === \n"
+  local fromClause="business_datasources"
+
+  for option in "${queryOptions[@]}"
+  do
+    whereClauseAndDescription=$(buildCountConditions $option)
+    countOutput="$countOutput $whereClauseAndDescription[0]:"
+    countOutput="$countOutput $(executeCountQuery $fromClause $whereClauseAndDescription[1]) \n"
+  done
+
+  return $countOutput
+}
+
+function getTotalCounts {
+  totalCountOutput="Total Business Index:"
+
+  totalCountQuery="SELECT count(*) FROM $DBNAME.business_datasources"
+  totalCountOutput="$totalCountOutput $(impala-shell -B --quiet -i '$IMPALADAEMON' -q "$totalCountQuery") \n"
+
+  return $totalCountOutput 
+}
+ 
+echo getCountsForTradingStatus
+echo getCountsForSourceTypes


### PR DESCRIPTION
Impala `GetBusinessIndexCounts.sh` script updated to get counts per Trading status.

With the added complexity now in place it is not ideal to have this as a single script written in bash. We should try and port this to a Python script given time however this is the MVP version
